### PR TITLE
Map careplan data bidirectional

### DIFF
--- a/fhir_x_synthea_csv/to_fhir/__init__.py
+++ b/fhir_x_synthea_csv/to_fhir/__init__.py
@@ -5,9 +5,11 @@ Synthea CSV to FHIR R4 mappings.
 from .patient import map_patient
 from .observation import map_observation
 from .condition import map_condition
+from .careplan import map_careplan
 
 __all__ = [
     "map_patient",
     "map_observation", 
     "map_condition",
+    "map_careplan",
 ]

--- a/fhir_x_synthea_csv/to_fhir/careplan.py
+++ b/fhir_x_synthea_csv/to_fhir/careplan.py
@@ -1,0 +1,109 @@
+"""
+CarePlan mapper: Synthea CSV to FHIR R4 CarePlan resource.
+"""
+
+from typing import Any, Dict, Optional
+
+from ..common.transformers import (
+    create_reference,
+    to_fhir_date,
+)
+
+
+def _get(src: Dict[str, Any], *keys: str) -> Optional[Any]:
+    """Get first non-empty value from possible key variants."""
+    for key in keys:
+        if key in src and src.get(key) not in (None, ""):
+            return src.get(key)
+    return None
+
+
+def _build_status(src: Dict[str, Any]) -> str:
+    """
+    Determine CarePlan.status from presence of STOP date.
+    active if no STOP date, completed if STOP present.
+    """
+    stop_date = _get(src, "STOP", "Stop")
+    return "completed" if stop_date else "active"
+
+
+def _build_category(src: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build CarePlan.category[0] from SNOMED code and description."""
+    code = _get(src, "CODE", "Code")
+    display = _get(src, "DESCRIPTION", "Description")
+    if not code:
+        return None
+    return {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": code,
+                "display": display,
+            }
+        ],
+        "text": display,
+    }
+
+
+def _build_period(src: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build CarePlan.period from Start/Stop dates."""
+    start = _get(src, "START", "Start")
+    stop = _get(src, "STOP", "Stop")
+    if not start and not stop:
+        return None
+    return {
+        "start": to_fhir_date(start) if start else None,
+        "end": to_fhir_date(stop) if stop else None,
+    }
+
+
+def _build_reason_note(src: Dict[str, Any]) -> Optional[list]:
+    """Optionally include reason as a note since R4 lacks top-level reasonCode."""
+    reason_code = _get(src, "REASONCODE", "ReasonCode")
+    reason_desc = _get(src, "REASONDESCRIPTION", "ReasonDescription")
+    if not reason_code and not reason_desc:
+        return None
+    text_parts = []
+    if reason_desc:
+        text_parts.append(str(reason_desc))
+    if reason_code:
+        text_parts.append(f"({reason_code})")
+    return [{"text": "Reason: " + " ".join(text_parts)}]
+
+
+def filter_none_values(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None/empty list/empty string values from dict."""
+    return {k: v for k, v in d.items() if v is not None and v != [] and v != ""}
+
+
+def careplan_transform(src: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform Synthea careplan to FHIR CarePlan."""
+    category = _build_category(src)
+    period = _build_period(src)
+    result: Dict[str, Any] = {
+        "resourceType": "CarePlan",
+        "id": _get(src, "Id", "ID"),
+        "status": _build_status(src),
+        "intent": "plan",
+        "category": [category] if category else None,
+        "title": _get(src, "DESCRIPTION", "Description"),
+        "description": _get(src, "DESCRIPTION", "Description"),
+        "subject": create_reference("Patient", _get(src, "PATIENT", "Patient")) if _get(src, "PATIENT", "Patient") else None,
+        "encounter": create_reference("Encounter", _get(src, "ENCOUNTER", "Encounter")) if _get(src, "ENCOUNTER", "Encounter") else None,
+        "period": period,
+        "note": _build_reason_note(src),
+    }
+    return filter_none_values(result)
+
+
+def map_careplan(synthea_careplan: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Convert Synthea CSV careplan to FHIR CarePlan resource.
+
+    Args:
+        synthea_careplan: Dictionary with Synthea careplan CSV fields
+
+    Returns:
+        FHIR CarePlan resource as dictionary
+    """
+    return careplan_transform(synthea_careplan)

--- a/fhir_x_synthea_csv/to_synthea_csv/__init__.py
+++ b/fhir_x_synthea_csv/to_synthea_csv/__init__.py
@@ -8,9 +8,11 @@ Synthea CSV format, enabling bidirectional semantic data mapping.
 from .patient import map_fhir_patient_to_csv
 from .observation import map_fhir_observation_to_csv
 from .condition import map_fhir_condition_to_csv
+from .careplan import map_fhir_careplan_to_csv
 
 __all__ = [
     "map_fhir_patient_to_csv",
     "map_fhir_observation_to_csv", 
     "map_fhir_condition_to_csv",
+    "map_fhir_careplan_to_csv",
 ]

--- a/fhir_x_synthea_csv/to_synthea_csv/careplan.py
+++ b/fhir_x_synthea_csv/to_synthea_csv/careplan.py
@@ -1,0 +1,104 @@
+"""
+CarePlan reverse mapper: FHIR R4 CarePlan resource to Synthea CSV careplans.
+"""
+
+from typing import Any, Dict, Optional
+
+from ..common.reverse_transformers import (
+    parse_fhir_date,
+    extract_reference_id,
+    extract_coding_by_system,
+    safe_get_first,
+)
+
+
+def filter_none_values(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None values but keep empty strings for CSV stability."""
+    return {k: (v if v is not None else "") for k, v in d.items()}
+
+
+def _extract_category_code_and_display(fhir_careplan: Dict[str, Any]) -> tuple[Optional[str], Optional[str], str]:
+    """Extract SNOMED code and display from CarePlan.category."""
+    system_default = "http://snomed.info/sct"
+    category_list = fhir_careplan.get("category") or []
+    category = safe_get_first(category_list)
+    if isinstance(category, dict):
+        snomed = extract_coding_by_system(category, system_default)
+        if snomed:
+            return snomed.get("code"), snomed.get("display"), system_default
+        coding_list = category.get("coding", [])
+        if coding_list:
+            first = safe_get_first(coding_list)
+            if isinstance(first, dict):
+                return first.get("code"), first.get("display"), first.get("system", system_default)
+        # Fallback to text
+        if category.get("text"):
+            return None, category.get("text"), system_default
+    return None, None, system_default
+
+
+def _extract_reason_from_notes(fhir_careplan: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    """Attempt to parse reasonCode/Description from CarePlan.note text (if previously encoded)."""
+    notes = fhir_careplan.get("note") or []
+    if not isinstance(notes, list):
+        return None, None
+    for note in notes:
+        if isinstance(note, dict) and note.get("text"):
+            text = str(note.get("text"))
+            # Expected pattern: "Reason: <desc> (<code>)" but be tolerant
+            if text.lower().startswith("reason:"):
+                body = text.split(":", 1)[1].strip()
+                # Try to split code in parentheses
+                if body.endswith(")") and "(" in body:
+                    desc, code_part = body.rsplit("(", 1)
+                    return code_part[:-1].strip() or None, desc.strip() or None
+                return None, body or None
+    return None, None
+
+
+def fhir_careplan_to_csv_transform(fhir_careplan: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform FHIR CarePlan to Synthea CSV careplan format."""
+    if not fhir_careplan or fhir_careplan.get("resourceType") != "CarePlan":
+        raise ValueError("Input must be a FHIR CarePlan resource")
+
+    careplan_id = fhir_careplan.get("id")
+
+    period = fhir_careplan.get("period", {}) if isinstance(fhir_careplan.get("period"), dict) else {}
+    start_date = parse_fhir_date(period.get("start"))
+    stop_date = parse_fhir_date(period.get("end"))
+
+    subject_id = extract_reference_id(fhir_careplan.get("subject"))
+    encounter_id = extract_reference_id(fhir_careplan.get("encounter"))
+
+    code, display, system = _extract_category_code_and_display(fhir_careplan)
+
+    # Try to pull reason out of R5-style fields if present, else from notes
+    reason_code, reason_desc = _extract_reason_from_notes(fhir_careplan)
+
+    result = {
+        "Id": careplan_id,
+        "START": start_date,
+        "STOP": stop_date,
+        "PATIENT": subject_id,
+        "ENCOUNTER": encounter_id,
+        "SYSTEM": system,
+        "CODE": code,
+        "DESCRIPTION": display or fhir_careplan.get("title") or fhir_careplan.get("description"),
+        "REASONCODE": reason_code,
+        "REASONDESCRIPTION": reason_desc,
+    }
+
+    return filter_none_values(result)
+
+
+def map_fhir_careplan_to_csv(fhir_careplan: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Convert FHIR CarePlan resource to Synthea CSV careplan format.
+
+    Args:
+        fhir_careplan: FHIR CarePlan resource as dictionary
+
+    Returns:
+        Synthea CSV careplan as dictionary
+    """
+    return fhir_careplan_to_csv_transform(fhir_careplan)

--- a/specs/to_fhir/careplan.md
+++ b/specs/to_fhir/careplan.md
@@ -1,0 +1,24 @@
+# CarePlan
+
+## Semantic Context
+The CarePlan resource represents a healthcare plan for a patient over a period of time. This mapping transforms Synthea CSV careplan data into FHIR R4 CarePlan resources.
+
+## Field Mappings
+| Source Field | Target Field | Semantic Concept | Transform | Notes |
+|--------------|--------------|------------------|-----------|-------|
+| careplans.Id | CarePlan.id | Resource Identifier | Direct copy | Primary key from CSV |
+| careplans.Start | CarePlan.period.start | Plan start date | Format as YYYY-MM-DD | When plan was initiated |
+| careplans.Stop | CarePlan.period.end | Plan end date | Format as YYYY-MM-DD | When plan ended (if applicable) |
+| careplans.Patient | CarePlan.subject | Patient Reference | Create Reference("Patient/{id}") | Patient the plan is for |
+| careplans.Encounter | CarePlan.encounter | Encounter Reference | Create Reference("Encounter/{id}") | Encounter where plan initiated |
+| careplans.Code | CarePlan.category[0].coding[0].code | SNOMED Code | Direct copy | SNOMED CT care plan concept |
+| careplans.Description | CarePlan.category[0].coding[0].display | Code Display | Direct copy | Human-readable display |
+| careplans.Code | CarePlan.category[0].coding[0].system | Code System | Set to "http://snomed.info/sct" | SNOMED CT system |
+| careplans.Description | CarePlan.title | Plan title | Direct copy | Fallback title |
+| careplans.Description | CarePlan.description | Plan description | Direct copy | Narrative description |
+| - | CarePlan.status | Plan status | Derive from Stop | "completed" if Stop present, else "active" |
+| - | CarePlan.intent | Plan intent | Set to "plan" | Default intent for CSV-based plan |
+| careplans.ReasonCode, careplans.ReasonDescription | CarePlan.note[0].text | Reason for plan | Concatenate ("Reason: {desc} ({code})") | R4 has no top-level reasonCode; encoded in note |
+
+## R5 Note
+In FHIR R5, `CarePlan.reason`/`reasonCode` is available. This mapping targets R4; reason is preserved in `CarePlan.note.text` for round-trip fidelity.


### PR DESCRIPTION
Add bidirectional mappings for CarePlan resources between Synthea CSV and FHIR R4.

Since FHIR R4 CarePlan lacks a direct `reasonCode` element, the `ReasonCode` and `ReasonDescription` from the CSV are encoded into `CarePlan.note.text` to ensure round-trip fidelity.

---
<a href="https://cursor.com/background-agent?bcId=bc-876e7776-4f15-4924-928d-8051f4aa17ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-876e7776-4f15-4924-928d-8051f4aa17ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added bidirectional mapping for CarePlan data between Synthea CSV and FHIR R4, including support for round-trip conversion of reason fields using CarePlan.note.text.

- **New Features**
 - Maps all core CarePlan fields between formats, including status, category, period, and references.
 - Encodes ReasonCode and ReasonDescription from CSV into FHIR note.text to preserve data not natively supported in R4.

<!-- End of auto-generated description by cubic. -->

